### PR TITLE
Fix PMA fault types for tagged reads

### DIFF
--- a/model/riscv_pma.sail
+++ b/model/riscv_pma.sail
@@ -101,14 +101,14 @@ register pma_regions : list(PMA_Region) = [||]
 function accessFaultFromAccessType (accTy : AccessType(ext_access_type)) -> ExceptionType =
   match accTy {
     Execute()  => E_Fetch_Access_Fault(),
-    Read(Data) => E_Load_Access_Fault(),
+    Read(_) => E_Load_Access_Fault(),
     _          => E_SAMO_Access_Fault()
   }
 
 function alignmentFaultFromAccessType(accTy : AccessType(ext_access_type)) -> ExceptionType =
   match accTy {
     Execute()  => E_Fetch_Addr_Align(),
-    Read(Data) => E_Load_Addr_Align(),
+    Read(_) => E_Load_Addr_Align(),
     _          => E_SAMO_Addr_Align()
   }
 


### PR DESCRIPTION
Tagged reads were causing STORE_AMO faults since the PMA exception type functions were matching on Read(Data) only.